### PR TITLE
Handle old load_zcml settings

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -27,7 +27,15 @@
   "zcml_include_file_location": "",
   "zcml_overrides_file_location": "",
   "zcml_resources_directory_location": "",
-  "load_zcml": "gone in 2.0",
+  "load_zcml": {
+    "package_metas": null,
+    "package_includes": null,
+    "package_overrides": null,
+    "locales_directory_location": "",
+    "include_file_location": "",
+    "overrides_file_location": "",
+    "resources_directory_location": ""
+  },
 
   "dos_protection_available": true,
   "dos_protection_form_memory_limit": "1MB",

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,5 +1,6 @@
-# invariant checks
+from collections import OrderedDict
 
+# invariant checks
 # check database mode direct and blobs not cache
 if (
     "{{ cookiecutter.db_storage }}" == "direct"
@@ -23,24 +24,32 @@ if 0 < len(password) < 10:
     )
 
 # version 2 config changes check
-upgrade_error = False
-if "{{ cookiecutter.load_zcml }}" != "gone in 2.0":
-    print(
-        "Error: 'zcml' dict setting is removed in 2.0, use 'zcml_' prefix variables instead!\n"
+upgrade_warnings = []
+upgrade_errors = []
+load_zcml = {{ cookiecutter.load_zcml }}
+has_old_zcml = True if [value for value in load_zcml.values() if value] else False
+if has_old_zcml:
+    upgrade_warnings.append(
+        "The 'zcml' dict setting is removed in 2.0, use 'zcml_' prefix variables instead!"
     )
-    upgrade_error = True
 
 if "{{ cookiecutter.debug_mode in [True, False] }}" != "True":
-    print(
-        "Error: 'debug_mode' setting must be boolean in 2.0, please fix your configuration!\n"
+    upgrade_errors.append(
+        "The 'debug_mode' setting must be boolean in 2.0, please fix your configuration!\n"
     )
-    upgrade_error = True
 
 if "{{ cookiecutter.verbose_security in [True, False] }}" != "True":
-    print(
-        "Error: 'verbose_security' setting must be boolean in 2.0, please fix your configuration!\n"
+    upgrade_errors.append(
+        "The'verbose_security' setting must be boolean in 2.0, please fix your configuration!\n"
     )
-    upgrade_error = True
 
-if upgrade_error:
+if upgrade_errors:
+    print("The following errors prevent cookiecutter-zope-instance from continuing, please fix them:")
+    for error_msg in upgrade_errors:
+        print(f" - Error: {error_msg}")
     exit(1)
+
+elif upgrade_warnings:
+    print("Please review the following warning messages and fix them at your earliest convenience:")
+    for warning_msg in upgrade_warnings:
+        print(f" - Warning: {warning_msg}")

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -27,7 +27,7 @@ if 0 < len(password) < 10:
 upgrade_warnings = []
 upgrade_errors = []
 load_zcml = {{ cookiecutter.load_zcml }}
-has_old_zcml = True if [value for value in load_zcml.values() if value] else False
+has_old_zcml = bool([value for value in load_zcml.values() if value])
 if has_old_zcml:
     upgrade_warnings.append(
         "The 'zcml' dict setting is removed in 2.0, use 'zcml_' prefix variables instead!"

--- a/{{ cookiecutter.target }}/etc/site.zcml
+++ b/{{ cookiecutter.target }}/etc/site.zcml
@@ -1,4 +1,18 @@
-<configure
+{%- set old_zcml = cookiecutter.load_zcml %}
+{%- set old_zcml_package_metas = ",".join(old_zcml.package_metas) if old_zcml.package_metas else ""  %}
+{%- set old_zcml_package_includes = ",".join(old_zcml.package_includes) if old_zcml.package_includes else ""  %}
+{%- set old_zcml_package_overrides = ",".join(old_zcml.package_overrides) if old_zcml.package_overrides else ""  %}
+{%- set old_zcml_locales_directory_location = old_zcml.locales_directory_location if old_zcml.locales_directory_location else ""  %}
+{%- set old_zcml_include_file_location = old_zcml.include_file_location if old_zcml.include_file_location else ""  %}
+{%- set old_zcml_overrides_file_location = old_zcml.overrides_file_location if old_zcml.overrides_file_location else ""  %}
+{%- set old_zcml_resources_directory_location = old_zcml.resources_directory_location if old_zcml.resources_directory_location else ""  %}
+{%- set zcml_package_metas = old_zcml_package_metas if old_zcml_package_metas else cookiecutter.zcml_package_metas %}
+{%- set zcml_package_includes = old_zcml_package_includes if old_zcml_package_includes else cookiecutter.zcml_package_includes %}
+{%- set zcml_package_overrides = old_zcml_package_overrides if old_zcml_package_overrides else cookiecutter.zcml_package_overrides %}
+{%- set zcml_locales_directory_location = old_zcml_locales_directory_location if old_zcml_locales_directory_location else cookiecutter.zcml_locales_directory_location %}
+{%- set zcml_include_file_location = old_zcml_include_file_location if old_zcml_include_file_location else cookiecutter.zcml_include_file_location %}
+{%- set zcml_overrides_file_location = old_zcml_overrides_file_location if old_zcml_overrides_file_location else cookiecutter.zcml_overrides_file_location %}
+{%- set zcml_resources_directory_location = old_zcml_resources_directory_location if old_zcml_resources_directory_location else cookiecutter.zcml_resources_directory_location %}<configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:meta="http://namespaces.zope.org/meta"
     xmlns:five="http://namespaces.zope.org/five">
@@ -9,49 +23,49 @@
 
   <meta:redefinePermission from="zope2.Public" to="zope.Public" />
 
-{%- if cookiecutter.zcml_locales_directory_location %}
+{%- if zcml_locales_directory_location %}
   <!-- Load the local locales  -->
-  <i18n:registerTranslations directory="{{ cookiecutter.zcml_locales_directory_location | abspath }}" />
+  <i18n:registerTranslations directory="{{ zcml_locales_directory_location | abspath }}" />
 {%- endif %}
 
-{%- if cookiecutter.zcml_package_metas %}
+{%- if zcml_package_metas %}
   <!-- META -->
-{%- for value in cookiecutter.zcml_package_metas.split(",") %}
+{%- for value in zcml_package_metas.split(",") %}
   <include package="{{ value.strip() }}" file="meta.zcml" />
 {%- endfor %}
 {%- endif %}
   <five:loadProducts file="meta.zcml"/>
 
-{%- if cookiecutter.zcml_package_includes %}
-  <!-- INCLUDES {{ cookiecutter.zcml_package_includes }} -->
-{%- for value in cookiecutter.zcml_package_includes.split(",") %}
+{%- if zcml_package_includes %}
+  <!-- INCLUDES {{ zcml_package_includes }} -->
+{%- for value in zcml_package_includes.split(",") %}
   <include package="{{ value.strip() }}" />
 {%- endfor %}
 {%- endif %}
   <five:loadProducts />
 
-{%- if cookiecutter.zcml_include_file_location %}
+{%- if zcml_include_file_location %}
   <!-- Load the local configuration:  -->
-  <include file="{{ cookiecutter.zcml_include_file_location | abspath }}" />
+  <include file="{{ zcml_include_file_location | abspath }}" />
 {%- endif %}
 
-{%- if cookiecutter.zcml_package_overrides %}
+{%- if zcml_package_overrides %}
   <!-- OVERRIDES -->
-{%- for value in cookiecutter.zcml_package_overrides.split(",") %}
+{%- for value in zcml_package_overrides.split(",") %}
   <includeOverrides package="{{ value.strip() }}" file="overrides.zcml"/>
 {%- endfor %}
 {%- endif %}
   <five:loadProductsOverrides />
 
-{%- if cookiecutter.zcml_overrides_file_location %}
+{%- if zcml_overrides_file_location %}
   <!-- Load the local overrides  -->
-  <include file="{{ cookiecutter.zcml_overrides_file_location | abspath}}" />
+  <include file="{{ zcml_overrides_file_location | abspath}}" />
 {%- endif %}
 
-{%- if cookiecutter.zcml_resources_directory_location %}
+{%- if zcml_resources_directory_location %}
   <!-- RESOURCES -->
   <include package="plone.resource" file="meta.zcml"/>
-  <plone:static directory="{{ cookiecutter.zcml_resources_directory_location | abspath}}"/>
+  <plone:static directory="{{ zcml_resources_directory_location | abspath}}"/>
 {%- endif %}
 
   <securityPolicy component="AccessControl.security.SecurityPolicy" />


### PR DESCRIPTION
Provide fallback with a warning if `instance.yaml` has the old `load_zcml` key.