### PR TITLE
Fix typos in docs and deprecation: zcml_package_metas and load_zcml.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,7 +31,7 @@ Changelog
 2.0.1
 -----
 
-- Fix: Implement a fallback to old zcml configurations Fixes #18.
+- Fix: Implement a fallback to use ``load_zcml`` dict configuration, effectively making the breaking change of its removal in 2.0.0 a deprecation instead. Fixes #18.
   [@ericof, 2024-03-01]
 
 2.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+2.1.2 (unreleased)
+------------------
+
+- Fix typo in docs: it is not ``zcml_package_meta`` singular, but ``zcml_package_metas`` plural.
+  [@mauritsvanrees, 2024-08-29]
+
+- Fix typo in deprecation warning: there was never a ``zcml`` dict setting, only ``load_zcml`.
+  [@mauritsvanrees, 2024-08-29]
+
 2.1.1
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -178,7 +178,7 @@ Initial user
 ZCML
 ----
 
-``zcml_package_meta``
+``zcml_package_metas``
     A string with comma separated values of ``meta.zcml`` files from packages to include.
 
     Examples: "my.fancypackage" or "myns.mypackage, collective.example"

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -32,7 +32,7 @@ load_zcml = {{ cookiecutter.load_zcml }}
 has_old_zcml = bool([value for value in load_zcml.values() if value])
 if has_old_zcml:
     upgrade_warnings.append(
-        "The 'zcml' dict setting is removed in 2.0, use 'zcml_' prefix variables instead!"
+        "The 'load_zcml' dict setting is deprecated in 2.0, use 'zcml_' prefix variables instead!"
     )
 
 if "{{ cookiecutter.debug_mode in [True, False] }}" != "True":

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -32,7 +32,7 @@ load_zcml = {{ cookiecutter.load_zcml }}
 has_old_zcml = bool([value for value in load_zcml.values() if value])
 if has_old_zcml:
     upgrade_warnings.append(
-        "The 'load_zcml' dict setting is deprecated in 2.0, use 'zcml_' prefix variables instead!"
+        "The 'load_zcml' dict setting was deprecated in version 2.0. Instead use the name of its keys prefixed with 'zcml_' as the new variable names."
     )
 
 if "{{ cookiecutter.debug_mode in [True, False] }}" != "True":


### PR DESCRIPTION
- Fix typo in docs: it is not `zcml_package_meta` singular, but `zcml_package_metas` plural. I tried the singular, but it was not working, so had to dive into the code.

- Fix typo in deprecation warning: there was never a `zcml` dict setting, only `load_zcml`. I kept seeing a deprecation warning that I should not be using a `zcml` dict, but I was not actually using it, so I never knew what or where to fix. And the setting is not actually removed, but it is deprecated.  Changed the warning accordingly.